### PR TITLE
Implement Canvas and Shape

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,5 +3,138 @@
 version = 3
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "getrandom"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.168"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aaeb2981e0606ca11d79718f8bb01164f1d6ed75080182d3abf017e6d244b6d"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.90"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "919d3b74a5dd0ccd15aeb8f93e7006bd9e14c295087c9896a110f490752bcf31"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "tech-test"
 version = "0.1.0"
+dependencies = [
+ "rand",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+
+[dev-dependencies]
+rand = "0.8.5"

--- a/src/main.rs
+++ b/src/main.rs
@@ -152,7 +152,7 @@ mod tests {
         canvas.set_origin(&single_handle, (20.0, 20.0));
         assert_eq!(canvas.get_origin(&single_handle), Some((20.0, 20.0)));
 
-        // check the layout of the canvas buffer reflects the
+        // check the layout of the canvas buffer reflects the change we just made
         for (i, handle) in canvas.shapes.iter().enumerate() {
             assert_eq!(
                 handle.read().unwrap().origin(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,7 @@ impl Canvas {
 
     fn set_origin<S: Shape>(&self, shape: &Handle<S>, origin: (f64, f64)) {
         // todo: possibly useful to return a Result here indicating whether the shape existed and
-        // was modified
+        // was modified. Also possibly desirable to crash on poisoned lock.
         if let Some(mut s) = shape.write().ok() {
             s.set_origin(origin)
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,169 @@
-fn main() {
-    println!("Hello, world!");
+use std::sync::{Arc, RwLock};
+
+mod shape;
+use shape::*;
+
+type Handle<S> = Arc<RwLock<S>>;
+
+struct Canvas {
+    // the downside of this handle / storage solution is its triple indirection, necessary though
+    // it is to allow individual shape manipulation and heterogeneous storage
+    shapes: Vec<Handle<dyn Shape>>,
 }
+
+impl Canvas {
+    fn new() -> Self {
+        Canvas { shapes: Vec::new() }
+    }
+
+    fn add<S: Shape + 'static>(&mut self, shape: S) -> Handle<S> {
+        let shape = Arc::new(RwLock::from(shape));
+        self.shapes.push(shape.clone());
+        shape
+    }
+
+    fn get_area<S: Shape>(&self, shape: &Handle<S>) -> Option<f64> {
+        shape.read().ok().map(|s| s.get_area())
+    }
+
+    fn get_origin<S: Shape>(&self, shape: &Handle<S>) -> Option<(f64, f64)> {
+        shape.read().ok().map(|s| s.origin())
+    }
+
+    fn set_origin<S: Shape>(&self, shape: &Handle<S>, origin: (f64, f64)) {
+        // todo: possibly useful to return a Result here indicating whether the shape existed and
+        // was modified
+        if let Some(mut s) = shape.write().ok() {
+            s.set_origin(origin)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::seq::SliceRandom;
+    use rand::thread_rng;
+    use rand::Rng;
+    use std::thread;
+
+    #[test]
+    fn shared_handle() {
+        let mut canvas = Canvas::new();
+        let circle = canvas.add(Circle {
+            radius: 5.0,
+            origin: (10.0, 10.0),
+        });
+        let rectangle = canvas.add(Rectangle {
+            width: 4.0,
+            height: 6.0,
+            origin: (20.0, 20.0),
+        });
+        let triangle = canvas.add(Triangle {
+            base: 3.0,
+            height: 4.0,
+            origin: (30.0, 30.0),
+        });
+
+        assert_eq!(circle.read().unwrap().origin(), (10.0, 10.0));
+        assert_eq!(rectangle.read().unwrap().origin(), (20.0, 20.0));
+        assert_eq!(triangle.read().unwrap().origin(), (30.0, 30.0));
+
+        circle.write().unwrap().origin = (11.0, 11.0);
+        assert_eq!(canvas.get_origin(&circle), Some((11.0, 11.0)));
+
+        rectangle.write().unwrap().origin = (21.0, 21.0);
+        assert_eq!(canvas.get_origin(&rectangle), Some((21.0, 21.0)));
+
+        canvas.set_origin(&triangle, (31.0, 31.0));
+        assert_eq!(canvas.get_origin(&triangle), Some((31.0, 31.0)));
+    }
+
+    #[test]
+    fn concurrent_access() {
+        let mut canvas = Canvas::new();
+        let handles = (0..100)
+            .map(|_| {
+                canvas.add(Rectangle {
+                    width: 4.0,
+                    height: 5.0,
+                    origin: (10.0, 10.0),
+                })
+            })
+            .collect::<Vec<_>>();
+
+        let handle1 = thread::spawn({
+            let mut handles = handles.clone();
+            move || {
+                handles.shuffle(&mut thread_rng());
+
+                for handle in handles {
+                    handle.write().unwrap().set_origin((0.0, 0.0));
+                }
+            }
+        });
+
+        let handle2 = thread::spawn({
+            let mut handles = handles.clone();
+            move || {
+                handles.shuffle(&mut thread_rng());
+
+                for handle in handles {
+                    handle.write().unwrap().set_origin((0.0, 0.0));
+                }
+            }
+        });
+
+        handle1.join().unwrap();
+        handle2.join().unwrap();
+
+        for handle in handles {
+            assert_eq!(canvas.get_origin(&handle), Some((0.0, 0.0)));
+        }
+    }
+
+    #[test]
+    fn single_handle_mutation() {
+        // not a fan of unit tests that 'know' implementation details, in this case the Canvas'
+        // buffer, so this is not as much a test as an illustration of handle tracking and uniqueness
+        let mut canvas = Canvas::new();
+
+        // adds 100 identical shapes, tracks a single shape
+        let (single_handle, index) = {
+            let mut single_handle = None;
+            let range = 0..100;
+            let index = rand::thread_rng().gen_range(range.clone());
+
+            for i in range {
+                let handle = canvas.add(Circle {
+                    radius: 5.0,
+                    origin: (10.0, 10.0),
+                });
+
+                if i == index {
+                    single_handle = Some(handle.clone());
+                }
+            }
+
+            (single_handle.expect("index should be in range"), index)
+        };
+
+        // mutate the tracked shape
+        canvas.set_origin(&single_handle, (20.0, 20.0));
+        assert_eq!(canvas.get_origin(&single_handle), Some((20.0, 20.0)));
+
+        // check the layout of the canvas buffer reflects the
+        for (i, handle) in canvas.shapes.iter().enumerate() {
+            assert_eq!(
+                handle.read().unwrap().origin(),
+                if i == index {
+                    (20.0, 20.0)
+                } else {
+                    (10.0, 10.0)
+                }
+            );
+        }
+    }
+}
+
+fn main() {}

--- a/src/main.rs
+++ b/src/main.rs
@@ -123,7 +123,7 @@ mod tests {
     }
 
     #[test]
-    fn single_handle_mutation() {
+    fn internal_layout() {
         // not a fan of unit tests that 'know' implementation details, in this case the Canvas'
         // buffer, so this is not as much a test as an illustration of handle tracking and uniqueness
         let mut canvas = Canvas::new();

--- a/src/shape.rs
+++ b/src/shape.rs
@@ -1,0 +1,66 @@
+use std::f64::consts::PI;
+
+pub trait Shape: Send + Sync {
+    fn get_area(&self) -> f64;
+    fn origin(&self) -> (f64, f64);
+    fn set_origin(&mut self, origin: (f64, f64));
+}
+
+pub struct Circle {
+    pub radius: f64,
+    pub origin: (f64, f64),
+}
+
+impl Shape for Circle {
+    fn get_area(&self) -> f64 {
+        PI * self.radius * self.radius
+    }
+
+    fn origin(&self) -> (f64, f64) {
+        self.origin
+    }
+
+    fn set_origin(&mut self, origin: (f64, f64)) {
+        self.origin = origin;
+    }
+}
+
+pub struct Rectangle {
+    pub width: f64,
+    pub height: f64,
+    pub origin: (f64, f64),
+}
+
+impl Shape for Rectangle {
+    fn get_area(&self) -> f64 {
+        self.width * self.height
+    }
+
+    fn origin(&self) -> (f64, f64) {
+        self.origin
+    }
+
+    fn set_origin(&mut self, origin: (f64, f64)) {
+        self.origin = origin;
+    }
+}
+
+pub struct Triangle {
+    pub base: f64,
+    pub height: f64,
+    pub origin: (f64, f64),
+}
+
+impl Shape for Triangle {
+    fn get_area(&self) -> f64 {
+        0.5 * self.base * self.height
+    }
+
+    fn origin(&self) -> (f64, f64) {
+        self.origin
+    }
+
+    fn set_origin(&mut self, origin: (f64, f64)) {
+        self.origin = origin;
+    }
+}


### PR DESCRIPTION
## Problem

- [x] Implement a Canvas struct to contain the Shapes.
- [x] Implement the Shape trait so that it exposes `get_area`, `origin` and `set_origin`.
- [x] Implement the Shape trait for 3 shapes: Circle, Rectangle, and Triangle.
- [x] Implement origin and set_origin methods on Shape to get and set respectively an x,y coordinate for the shape.
- [x] Implement methods `add`, `get_area`, and `set_origin` on Canvas which each handle a single Shape.
- [x] Extend the implementation to make the Canvas safe for multi-threaded use. In this case, a shape's origin should be modifiable from any thread, ideally without having to lock the entire Canvas exclusively.

## Solution

As per the above specified requirements, this pull request adds a `Canvas`, which stores heterogeneous objects all satisfying the `Shape` trait.

Shapes are boxed using an atomic reference counting pointer, and protected by a RwLock (assuming non-exclusive locking might happen more frequently than exclusive, another lock may be more suitable depending on the use case). A handle to the shape is returned for each shape added, allowing the caller to obtain exclusive access to the shape. As the spec called for it, the canvas can also be used to mutate a shape contained within (though this is equivalent to using the handle directly).

The shape trait and concrete shapes are located in the `shape` module, and the canvas, as well as demonstrative test suite are in `main.rs`.

## Reviewer instructions

The project's test can be run simply with `cargo test`, as evidenced by the empty main function this will compile a noop executable if built or run as such.
